### PR TITLE
perf(pencil): Pin keycutter to 1.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'keycutter'
+gem 'keycutter', '= 1.0.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PLATFORMS
   arm64-darwin-22
 
 DEPENDENCIES
-  keycutter
+  keycutter (= 1.0.2)
 
 BUNDLED WITH
    2.4.1


### PR DESCRIPTION
BREAKING CHANGE: Becuase we should be using 1.0.0 now

Signed-off-by: Dan Webb <dan.webb@damacus.io>
