### PR TITLE
fix: Use the entrypoint to reliably set the WORKING_DIRECTORY

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: "."
 runs:
   using: "docker"
-  image: docker://ghcr.io/actionshub/publish-gem-to-github:v1.0.10
+  image: docker://ghcr.io/actionshub/publish-gem-to-github:v1.0.11
   args:
     - ${{ inputs.token }}
     - ${{ inputs.owner }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,8 +10,7 @@ TOKEN="${INPUT_TOKEN}"
 OWNER="${INPUT_OWNER:-$GITHUB_REPOSITORY_OWNER}"
 [ -z "${OWNER}" ] && { echo "Error: no owner set"; exit 2; }
 
-WORKING_DIRECTORY="${INPUT_WORKING_DIRECTORY}"
-[ -z "${WORKING_DIRECTORY}" ] && { echo "Error: missing working directory"; exit 2; }
+WORKING_DIRECTORY="${INPUT_WORKING_DIRECTORY:-.}"
 
 function setup_credentials_file() {
   echo "Setting up access to RubyGems"


### PR DESCRIPTION
We have WORKING_DIRECTORY set to default to "." in the actions.yml but
this seems to be informational

Signed-off-by: Dan Webb <dan.webb@damacus.io>
